### PR TITLE
Handling numbers must be culture-independent

### DIFF
--- a/src/JsonLD/Core/RDFDataset.cs
+++ b/src/JsonLD/Core/RDFDataset.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using JsonLD.Core;
 using Newtonsoft.Json.Linq;
 
@@ -220,7 +221,7 @@ namespace JsonLD.Core
                                 {
                                     try
                                     {
-                                        double d = double.Parse(value);
+                                        double d = double.Parse(value, CultureInfo.InvariantCulture);
                                         if (!double.IsNaN(d) && !double.IsInfinity(d))
                                         {
                                             if (JSONLDConsts.XsdInteger.Equals(type))

--- a/src/JsonLD/Core/RDFDataset.cs
+++ b/src/JsonLD/Core/RDFDataset.cs
@@ -747,7 +747,7 @@ namespace JsonLD.Core
                                 value = new JValue((double)number);
                             }
                             // canonical double representation
-                            return new RDFDataset.Literal(string.Format("{0:0.0###############E0}", (double)value), datatype.IsNull() ? JSONLDConsts.XsdDouble
+                            return new RDFDataset.Literal(string.Format(CultureInfo.InvariantCulture, "{0:0.0###############E0}", (double)value), datatype.IsNull() ? JSONLDConsts.XsdDouble
                                  : (string)datatype, null);
                         }
                         else

--- a/tests/JsonLD.Test/ConformanceTests.cs
+++ b/tests/JsonLD.Test/ConformanceTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -18,6 +20,8 @@ namespace JsonLD.Test
         [Theory, ClassData(typeof(ConformanceCases))]
         public void ConformanceTestPasses(string id, string testname, ConformanceCase conformanceCase)
         {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("pl");
+
             JToken result = conformanceCase.run();
             if (conformanceCase.error != null)
             {


### PR DESCRIPTION
This fixed reading and writing double values in RDF, when culture defines a non-standard decimal point. For example Polish uses a comma instead of a period.

Excuse my setting the `Thread.CurrentThread.CurrentCulture` to some arbitrary value. If there's a proper way to with xUnit please let me know